### PR TITLE
begin adding spans to AST nodes

### DIFF
--- a/src/ast/expressions.rs
+++ b/src/ast/expressions.rs
@@ -1,4 +1,5 @@
 use lexer::TokenKind;
+use token::Spanned;
 use super::{Arguments, Operand, Conversion, Type, Ident};
 
 // Expr = UnaryExpr | Expr binary_op Expr .
@@ -118,9 +119,9 @@ impl BinaryOperation {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryExpr {
-    pub lhs: Box<Expr>,
+    pub lhs: Box<Spanned<Expr>>,
     pub op: BinaryOperation,
-    pub rhs: Box<Expr>,
+    pub rhs: Box<Spanned<Expr>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,7 +133,7 @@ pub enum UnaryExpr {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnaryOperation {
     pub operator: UnaryOperator, // TODO: type safety
-    pub operand: Box<UnaryExpr>,
+    pub operand: Box<Spanned<UnaryExpr>>,
 }
 
 // TODO
@@ -228,8 +229,8 @@ pub struct SelectorExpr {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexExpr {
-    pub operand: Box<PrimaryExpr>,
-    pub index: Expr,
+    pub operand: Box<Spanned<PrimaryExpr>>,
+    pub index: Spanned<Expr>,
 }
 
 
@@ -244,7 +245,7 @@ pub struct IndexExpr {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SliceExpr {
-    pub operand: Box<PrimaryExpr>,
+    pub operand: Box<Spanned<PrimaryExpr>>,
     pub slicing: Slicing,
 }
 // XXX: naming
@@ -260,22 +261,22 @@ pub struct SliceExpr {
 // to max - low. Only the first index may be omitted; it defaults to 0. After slicing the array a
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Slicing {
-    pub low: Expr,
-    pub high: Expr,
-    pub max: Option<Expr>,
+    pub low: Spanned<Expr>,
+    pub high: Spanned<Expr>,
+    pub max: Option<Spanned<Expr>>,
 }
 
 /// A TypeAssertion contains the expression whose type is being asserted.
 /// This superficially differs from the grammar in the Go spec.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeAssertion {
-    pub expr: Box<PrimaryExpr>,
-    pub typ: String,
+    pub expr: Box<Spanned<PrimaryExpr>>,
+    pub typ: Spanned<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuncCall {
-    pub callee: Box<PrimaryExpr>,
+    pub callee: Box<Spanned<PrimaryExpr>>,
     pub args: Arguments,
 }
 

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -12,6 +12,7 @@ mod expressions;
 
 use num::bigint::BigInt;
 use num::BigRational;
+use token::Spanned;
 pub use self::types::*;
 pub use self::statements::*;
 pub use self::expressions::*;
@@ -35,7 +36,7 @@ pub struct SourceFile {
     /// Name of the package this file belongs to.
     pub package: Ident,
     /// All import declarations in this file.
-    pub import_decls: Vec<ImportDecl>,
+    pub import_decls: Vec<Spanned<ImportDecl>>,
     /// All top-level declarations in this file.
     pub top_level_decls: Vec<TopLevelDecl>,
 }
@@ -59,7 +60,7 @@ pub struct SourceFile {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportDecl {
-    pub specs: Vec<ImportSpec>,
+    pub specs: Vec<Spanned<ImportSpec>>,
 }
 
 /// An import spec.
@@ -83,7 +84,7 @@ pub struct ImportDecl {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportSpec {
     pub kind: ImportKind,
-    pub path: Vec<u8>,
+    pub path: Spanned<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -115,7 +116,7 @@ pub enum TopLevelDecl {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FuncDecl {
     // XXX: functions with same name but different origins, how do we handle them?
-    pub name: String,
+    pub name: Spanned<String>,
     pub signature: FuncSignature,
     pub body: Option<Block>,
 }
@@ -226,7 +227,7 @@ pub struct ConstDecl {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConstSpec {
-    pub idents: Vec<Ident>,
+    pub idents: Vec<Spanned<Ident>>,
     pub inner: Option<ConstSpecInner>,
 }
 
@@ -250,7 +251,7 @@ pub struct ConstSpecInner {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MethodDecl {
     pub receiver: Parameters,
-    pub name: Ident,
+    pub name: Spanned<Ident>,
     pub signature: FuncSignature,
     pub body: Option<Block>,
 }
@@ -267,14 +268,14 @@ pub struct MethodDecl {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeDecl {
-    pub specs: Vec<TypeSpec>,
+    pub specs: Vec<Spanned<TypeSpec>>,
 }
 
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeSpec {
-    pub ident: Ident,
-    pub typ: Type,
+    pub ident: Spanned<Ident>,
+    pub typ: Spanned<Type>,
 }
 
 /// A variable declaration creates one or more variables, binds corresponding identifiers to them,
@@ -287,7 +288,7 @@ pub struct TypeSpec {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VarDecl {
-    pub specs: Vec<VarSpec>,
+    pub specs: Vec<Spanned<VarSpec>>,
 }
 
 /// ## Grammar
@@ -297,9 +298,9 @@ pub struct VarDecl {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VarSpec {
-    pub idents: Vec<Ident>,
+    pub idents: Vec<Spanned<Ident>>,
     pub typ: Option<Type>,
-    pub exprs: Vec<Expr>,
+    pub exprs: Vec<Spanned<Expr>>,
 }
 
 /// Operands denote the elementary values in an expression. An operand may be a literal, a
@@ -329,17 +330,17 @@ pub enum Operand {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Conversion {
     /// The type to convert to.
-    pub typ: Type,
+    pub typ: Spanned<Type>,
     /// The expression being converted.
-    pub expr: Expr,
+    pub expr: Spanned<Expr>,
 }
 
 
 // ShortVarDecl = IdentifierList ":=" ExpressionList .
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShortVarDecl {
-    pub lhs: Vec<Ident>,
-    pub rhs: Vec<Expr>,
+    pub lhs: Vec<Spanned<Ident>>,
+    pub rhs: Vec<Spanned<Expr>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -376,7 +377,7 @@ pub enum BasicLit {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeLit {
-    pub typ: LiteralType,
+    pub typ: Spanned<LiteralType>,
     pub val: LiteralValue,
 }
 
@@ -398,8 +399,8 @@ pub struct LiteralValue {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KeyedElem {
-    pub key: Option<Key>,
-    pub elem: Elem,
+    pub key: Option<Spanned<Key>>,
+    pub elem: Spanned<Elem>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -438,6 +439,6 @@ pub struct FuncLit {
 /// functions: `make` and `new`, and these functions take a **type** instead of an expression
 /// as their first argument.
 pub struct Arguments {
-    pub typ: Option<Type>,
-    pub expressions: Vec<Expr>,
+    pub typ: Option<Spanned<Type>>,
+    pub expressions: Vec<Spanned<Expr>>,
 }

--- a/src/ast/statements.rs
+++ b/src/ast/statements.rs
@@ -1,4 +1,5 @@
 use super::{Block, Expr, ShortVarDecl, ConstDecl, TypeDecl, VarDecl, BinaryOperation};
+use token::Spanned;
 
 
 // Statement =
@@ -76,7 +77,7 @@ pub struct LabeledStmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GoStmt {
     /// The function or method call being started.
-    pub call: Expr,
+    pub call: Spanned<Expr>,
 }
 
 /// A "defer" statement invokes a function whose execution is deferred to the moment the
@@ -86,13 +87,13 @@ pub struct GoStmt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeferStmt {
     /// The function or method call being deferred.
-    pub call: Expr,
+    pub call: Spanned<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReturnStmt {
     /// The expression being returned.
-    pub expr: Expr,
+    pub expr: Spanned<Expr>,
 }
 
 
@@ -117,7 +118,7 @@ pub struct FallthroughStmt;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IfStmt {
     pub before_stmt: Option<SimpleStmt>,
-    pub condition: Expr,
+    pub condition: Spanned<Expr>,
     pub block: Block,
     pub opt_else: Option<Box<Else>>,
 }
@@ -173,27 +174,27 @@ pub struct RangeClause {
     /// The iteration variables.
     pub iter_vars: IterVars,
     /// The range expression.
-    pub expr: Expr,
+    pub expr: Spanned<Expr>,
 }
 
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IterVars {
-    Exprs(Vec<Expr>),
-    Idents(Vec<String>),
+    Exprs(Vec<Spanned<Expr>>),
+    Idents(Vec<Spanned<String>>),
 }
 
 // SendStmt = Channel "<-" Expression .
 // Channel  = Expression .
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SendStmt {
-    pub channel: Expr,
-    pub expr: Expr,
+    pub channel: Spanned<Expr>,
+    pub expr: Spanned<Expr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IncDecStmt {
-    pub expr: Expr,
+    pub expr: Spanned<Expr>,
     pub is_dec: bool, // false for ++, true for --
 }
 
@@ -201,8 +202,8 @@ pub struct IncDecStmt {
 // assign_op = [ add_op | mul_op ] "=" .
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Assignment {
-    pub lhs: Vec<Expr>,
-    pub rhs: Vec<Expr>,
+    pub lhs: Vec<Spanned<Expr>>,
+    pub rhs: Vec<Spanned<Expr>>,
     // binary operation used in assign op
     // XXX: add method to BinaryOperation to check if is a valid assign_op operation
     pub op: Option<BinaryOperation>,


### PR DESCRIPTION
This PR adds a few new types in `token`.

There are two new macros in the parser: `span!()` and `try_span!()`.

Many nodes in the AST are now wrapped in `Spanned<T>`. Note that this is quite unfinished, and we can't know exactly which nodes will need to be `Spanned` until semantic analysis is added.
